### PR TITLE
Add Stylesheet based on the main website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_site
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins

--- a/README.md
+++ b/README.md
@@ -17,5 +17,13 @@ Have fun, and happy hacking!
 If you would like to contribute to our documentation in any way (fixing
 typos, adding new docs, etc.), please fork the repo and make a new [Pull Request.][add-pr]
 
+### Building the site locally
+
+[This article explains in-depth how to build the site locally.][build-pages-locally]
+Before submitting a pull request, you should test that your
+changes appear correct by building and validating locally.
+
+
 [docs-link]: https://uwb-acm.github.io/Hackathon-Docs/
 [add-pr]: https://github.com/UWB-ACM/Hackathon-Docs/pulls
+[build-pages-locally]: https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,21 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+
+body {
+    background-color: #122232;
+}
+
+p
+{
+  color: white;
+}
+
+a
+{
+  color: white;
+  text-decoration: underline;
+  opacity: 0.8;
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -4,11 +4,15 @@
 @import "{{ site.theme }}";
 
 
+$background-color: #122232;
+$hover-color: rgba(#FFF, 0.8);
+$list-color: rgba(#FFF, 0.9);
+
 body {
-    background-color: #122232;
+    background-color: $background-color;
 }
 
-p
+p, h1, h2, h3, h4, h5, h6
 {
   color: white;
 }
@@ -18,4 +22,21 @@ a
   color: white;
   text-decoration: underline;
   opacity: 0.8;
+}
+
+a:hover, a:focus
+{
+  font-weight: unset;
+  color: $hover-color;
+}
+
+a > small
+{
+  color: $hover-color;
+}
+
+ul, li, ol
+{
+  color: $list-color;
+  list-style-type: circle;
 }


### PR DESCRIPTION
Adds a style to the docs that makes it look more like the event website.
Also adds instructions in the README showing contributors how to build the site locally for testing.


