### PR TITLE
Add Guides header

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,6 +30,7 @@
         <p class="view"><a href="{{ site.github.owner_url }}">View My GitHub Profile</a></p>
         {% endif %}
 
+        <h2>Guides</h2>
         {% for page in site.pages %}
           {% if page.categories contains 'guide' %}
             <a href="{{ site.baseurl }}{{ page.url }}">{{ page.title }}</a>
@@ -43,6 +44,9 @@
           <li><a href="{{ site.github.tar_url }}">Download <strong>TAR Ball</strong></a></li>
           <li><a href="{{ site.github.repository_url }}">View On <strong>GitHub</strong></a></li>
         </ul>
+
+        <br />
+        
         {% endif %}
       </header>
       <section>


### PR DESCRIPTION
Adds a "Guides" header over the lists of the guides that are in the page header/sidebar.